### PR TITLE
adding localization text in niveristand-fpga-addon-custom-device cont…

### DIFF
--- a/control
+++ b/control
@@ -13,3 +13,13 @@ Section: Add-Ons
 XB-DisplayVersion: {quarterly_display_version}
 XB-DisplayName: NI FPGA Addon for VeriStand {veristand_version}
 Depends: ni-veristand-{veristand_version} (>= {labview_short_version}.0.0)
+Description-zh-CN: 该附加工具允许用户将现有FPGA位文件提取到NI VeriStand中，无需进行修改或进行少量修改
+XB-DisplayName-zh-CN: NI FPGA Addon for VeriStand {veristand_version}
+Description-de: Das Zusatzpaket ermöglicht es dem Benutzer, eine vorhandene FPGA-Bitdatei mit nur wenigen oder keinen Änderungen in NI VeriStand zu verwenden
+XB-DisplayName-de: NI-FPGA-Zusatzpaket für VeriStand {veristand_version}
+Description-fr: Ce complément logiciel permet à un utilisateur d&apos;extraire un fichier bitfile FPGA existant dans NI VeriStand avec peu ou pas de modification
+XB-DisplayName-fr: NI FPGA Addon for VeriStand {veristand_version}
+Description-ja: このアドオンを使用すると、既存のFPGAビットファイルをほとんど、またはまったく変更せずにNI VeriStandに取り込むことができます。
+XB-DisplayName-ja: NI FPGAアドオン - VeriStand {veristand_version}用
+Description-ko: 이 애드온을 사용하면 기존 FPGA 비트 파일을 거의 또는 전혀 수정하지 않고 NI VeriStand로 가져올 수 있습니다.
+XB-DisplayName-ko: NI FPGA Addon - VeriStand {veristand_version} 지원


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-fpga-addon-custom-device/blob/master/CONTRIBUTING.md).

TODO: Include high-level description of the changes in this pull request.
As part of User Story (https://ni.visualstudio.com/DevCentral/_workitems/edit/2665528/) We are trying to include localization description for Chinese, German, Japanese, French, Korean languages for different VeriStand third party products.

TODO: Justify why this contribution should be part of the project.
Taken reference from VeriStand control page (‪\argo\ni\nipkg\pool\ni-v\ni-veristand-2024\24.0.0\24.0.0.49451-0+f299\ni-veristand-2024_24.0.0.49451-0+f299_windows_x64.nipkg.control) and edited niveristand-fpga-addon-custom-device control page accordingly.

TODO: Detail what testing has been done to ensure this submission meets requirements.
Testing is in progress